### PR TITLE
修复Sample FingerPrint模式下获取Host为空的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ As shown in the figure, we use the above sample Salt value and Host field as the
 According to splicing the above values, the sample fingerprint is obtained as follows:
 
 ```bash
-22e6db08c5ef1889d64103a290ac145c
+d56da55231dfd8e9a4f3ad2e464f49e4
 ```
 
 Now that we know the above sample fingerprint, we can set the custom Header field and sample fingerprint in the RedGuard configuration file for malicious traffic interception. It is worth noting that we can extend multiple sample fingerprints, separated by commas, and the FieldName needs to be consistent with the Header field name configured in the Malleable Profile

--- a/core/ProxyFilter.go
+++ b/core/ProxyFilter.go
@@ -127,7 +127,7 @@ func ProxyFilterManger(req *http.Request) (status bool) {
 
 	// sample finger verify
 	if f := req.Header.Get(fieldName); fieldName != "*" && fieldFinger != "*" && f != "" {
-		finger := lib.EncodeMD5(req.Header.Get("Host") + f)
+		finger := lib.EncodeMD5(req.Host + f)
 		logger.Noticef("Sample Finger: %s", finger)
 		if strings.Contains(fieldFinger, finger) /* finger Check*/ {
 			logger.Errorf("[DROP] Requested Sample Finger is forbidden to access")

--- a/doc/README_CN.md
+++ b/doc/README_CN.md
@@ -429,7 +429,7 @@ http-get "listen2" {
 根据对上述值进行拼接得到sample指纹为：
 
 ```bash
-22e6db08c5ef1889d64103a290ac145c
+d56da55231dfd8e9a4f3ad2e464f49e4
 ```
 
 目前已知上述样本指纹，现在我们在RedGuard配置文件中设置自定义的Header字段及样本指纹用于恶意流量拦截。值得注意的是，我们可以拓展多个样本指纹，不同指纹之间以逗号分隔，FieldName需要和Malleable Profile中配置的Header字段名称保持一致。


### PR DESCRIPTION
大佬您好，发现您写的RedGuard在Sample FingerPrint模式下存在一个问题，导致无法获取到真正的Host值，您在案例中给出的sample指纹 22e6db08c5ef1889d64103a290ac145c其实为866e5289337ab033f89bc57c5274c7ca的Hash。
```
//sample finger verify
if f := req.Header.Get(fieldName); fieldName != "*" && fieldFinger != "*" && f != "" {
	finger := lib.EncodeMD5(req.Header.Get("Host") + f) // req.Header.Get("Host")无法获取真正的Host应改为req.Host
	logger.Noticef("Sample Finger: %s", finger)
	if strings.Contains(fieldFinger, finger) /* finger Check*/ {
		logger.Errorf("[DROP] Requested Sample Finger is forbidden to access")
		return false
	}
}
```